### PR TITLE
Support non-default *print-case*

### DIFF
--- a/cruft.lisp
+++ b/cruft.lisp
@@ -115,7 +115,7 @@
         ;; Treat all these closures equivalent.
         (flet ((internal-dispatch-macro-closure-name-p (name)
                  (find "SB-IMPL::%MAKE-DISPATCH-MACRO-CHAR" name
-                       :key #'prin1-to-string :test #'string=)))
+                       :key #'prin1-to-string :test #'string-equal)))
           (let ((n1 (sb-impl::%fun-name fn1))
                 (n2 (sb-impl::%fun-name fn2)))
             (and (listp n1) (listp n2)


### PR DESCRIPTION
`function=` closure comparison fails under SBCL when `*print-case*` is not `:upcase` because `prin1-to-string` key depends on it. This patch fixes this by performing case-insensitive comparison. (I also though of uninterned symbol comparison, but that violates package locks.)
