### PR TITLE
Fixed DEFINE-API macro issue on CMUCL.

### DIFF
--- a/src/define-api.lisp
+++ b/src/define-api.lisp
@@ -37,13 +37,15 @@
                            collect `(check-type ,req-arg ,req-type))
 
                    ;; CHECK-TYPE optional parameters
-                   ,@(loop initially (assert (or (null opts)
-                                                 (eq (pop type-list) '&optional)))
-                           for (opt-arg . nil) in opts
-                           for opt-type = (pop type-list)
-                           do (assert opt-type)
-                           collect `(check-type ,opt-arg ,opt-type))
-
+                   ,@(progn
+                      (assert (or (null opts)
+                                  (eq (pop type-list) '&optional)))
+                      
+                      (loop for (opt-arg . nil) in opts
+                            for opt-type = (pop type-list)
+                            do (assert opt-type)
+                            collect `(check-type ,opt-arg ,opt-type)))
+                   
                    ;; CHECK-TYPE rest parameter
                    ,@(when rest
                        (assert (eq (pop type-list) '&rest))
@@ -53,10 +55,12 @@
                              (check-type x ,rest-type)))))
 
                    ;; CHECK-TYPE key parameters
-                   ,@(loop initially (assert (or (null keys)
-                                                 (eq (pop type-list) '&key)))
-                           for ((keyword key-arg)  . nil) in keys
-                           for (nil key-type) = (find keyword type-list :key #'car)
-                           collect `(check-type ,key-arg ,key-type)))
+                   ,@(progn
+                      (assert (or (null keys)
+                                  (eq (pop type-list) '&key)))
+                      
+                      (loop for ((keyword key-arg)  . nil) in keys
+                            for (nil key-type) = (find keyword type-list :key #'car)
+                            collect `(check-type ,key-arg ,key-type))))
 
                  ,@body))))))))


### PR DESCRIPTION
Fixed issue #9  when compiling named-readtables on CMUCL. The issue was caused by an assertion failure in the DEFINE-API macro, when checking the types of the optional parameters, namely the assertion which checks that either the OPTS list is empty or begins with &OPTIONAL. The reason for the assertion failure was that it was placed in the INITIALLY clause of the LOOP however the INITIALLY clause was being evaluated after the FOR variable initialization forms. The fix is to move the assertion out of the LOOP macro. I tested the fix on CMUCL 21c and named-readtables is loaded successfully using QL:QUICKLOAD.