### PR TITLE
Add a :modern readtable to the output of list-all-named-readtables

### DIFF
--- a/src/cruft.lisp
+++ b/src/cruft.lisp
@@ -42,7 +42,7 @@
 
 (define-cruft %list-all-readtable-names ()
   "Return a list of all available readtable names."
-  #+ :common-lisp (list* :standard :current
+  #+ :common-lisp (list* :standard :current :modern
                          (loop for name being each hash-value of *readtable-names*
                                collect name)))
 


### PR DESCRIPTION
This way, :modern readtable will become discoverable:

```
POFTHEDAY> (named-readtables:list-all-named-readtables)
(#<NAMED-READTABLE :CURRENT {100001CE23}>
 #<NAMED-READTABLE :CURRENT {100001CE23}>
 #<NAMED-READTABLE :MODERN {10027E9E13}>
 #<NAMED-READTABLE :PARENSCRIPT {1002F0EB93}>
 #<NAMED-READTABLE RUTILS.READTABLE:RUTILS-READTABLE {1002F0EBE3}>
 #<NAMED-READTABLE RUTILS.READTABLE:STANDARD-READTABLE {1002F0EC33}>)
```