### PR TITLE
Always switch the readtable for the given package

### DIFF
--- a/src/named-readtables.lisp
+++ b/src/named-readtables.lisp
@@ -181,13 +181,13 @@
   (let ((readtable-alist (find-symbol (string '#:*readtable-alist*)
 				      (find-package :swank))))
     (when (boundp readtable-alist)
-      (pushnew (cons (package-name package) readtable)
-	       (symbol-value readtable-alist)
-	       :test #'(lambda (entry1 entry2)
-			 (destructuring-bind (pkg-name1 . rt1) entry1
-			   (destructuring-bind (pkg-name2 . rt2) entry2
-			     (and (string= pkg-name1 pkg-name2)
-				  (eq rt1 rt2)))))))))
+      (let ((new-item (cons (package-name package) readtable)))
+        (setf (symbol-value readtable-alist)
+              (cons
+               new-item
+               (remove new-item (symbol-value readtable-alist)
+                       :test (lambda (entry1 entry2)
+                               (string= (car entry1) (car entry2))))))))))
 
 (deftype readtable-designator ()
   `(or null readtable))


### PR DESCRIPTION
Previously, named-readtables always pushnew-ed (cons package-name readtable) checking for both package-name and readtable.

So in interactive development, say I did (in-readtable :foo) followed by (in-readtable :bar) and then again (in-readtable :foo) all in the same package. This third time *readtable-alist* doesn't change. This results in us always being in the :bar readtable, and never being able to switch back to the :foo readtable.

I didn't see any obvious reason as to why named-readtables needed to store multiple values in the alist for the same package, so I've modified it to always change the readtable for the package, and this makes it a lot more pleasant to work with multiple readtables. (Obviously, ideally we'd like file-level readtable support, but this is a decent stop-gap solution)