### PR TITLE
more precisely & completely quiet SBCL's &optional-and-&key warning

### DIFF
--- a/src/define-api.lisp
+++ b/src/define-api.lisp
@@ -18,11 +18,9 @@
              (locally
                  ;;; Muffle the annoying "&OPTIONAL and &KEY found in
                  ;;; the same lambda list" style-warning
-                 #+sbcl (declare (sb-ext:muffle-conditions style-warning))
+                 #+sbcl (declare (sb-ext:muffle-conditions sb-kernel:&optional-and-&key-in-lambda-list))
                (defun ,name ,lambda-list
                  ,docstring
-
-                 #+sbcl (declare (sb-ext:unmuffle-conditions style-warning))
 
                  ,@decls
 


### PR DESCRIPTION
Prior to this commit, building this system in SBCL signaled a
style-warning of type `sb-kernel:&optional-and-&key-in-lambda-list`
from line 243 of [src/named-readtables.lisp], the definition of
`make-readtable`. This was despite obvious work in the definition of
`define-api` to prevent such warnings. This commit makes two
SBCL-specific changes, which result in that warning no longer being
printed:

1. `define-api` muffles only
   `sb-kernel:&optional-and-&key-in-lambda-list`, around its `defun`,
   not all of `style-warning`. This makes more obvious why the
   `locally muffle-conditions` is there, and prevents accidentally
   muffling other conditions.

2. `define-api` no longer unmuffles any conditions around its
   body. This means that `sb-kernel:&optional-and-&key-in-lambda-list`
   is muffled in both the definition and the body of `define-api`'s
   `defun` form. I suspect that unmuffling in the body is what caused
   `make-readtable` to issue that warning.